### PR TITLE
Add GRUSP conferences for 2022

### DIFF
--- a/_conferences/jsday-2022.md
+++ b/_conferences/jsday-2022.md
@@ -1,8 +1,12 @@
 ---
 name: "JsDay"
-website: https://2022.jsday.it/index.html
+website: https://jsday.it/
 location: Verona
 
 date_start: 2022-04-21
 date_end:   2022-04-22
+
+cfp_start: 2022-01-01
+cfp_end:   2022-02-01
+cfp_site:  https://docs.google.com/forms/d/e/1FAIpQLScwv7c7Mi-FA-q6s7_ckcxiHpxQrnjycHw2ahNJv7YOuPff4Q/viewform
 ---

--- a/_conferences/laravelday-2022.md
+++ b/_conferences/laravelday-2022.md
@@ -1,0 +1,9 @@
+---
+name: "laravelday"
+website: https://laravelday.it/
+location: Online
+online: true
+
+date_start: 2022-11-01
+date_end:   2022-11-01
+---

--- a/_conferences/phpday-2022.md
+++ b/_conferences/phpday-2022.md
@@ -1,8 +1,12 @@
 ---
 name: "phpday"
-website: https://2022.phpday.it/
+website: https://phpday.it/
 location: Verona
 
 date_start: 2022-05-19
 date_end:   2022-05-20
+
+cfp_start: 2022-01-01
+cfp_end:   2022-02-01
+cfp_site:  https://docs.google.com/forms/d/e/1FAIpQLSdTVD8Ijdg964oeTroWw6NLf2TVPOibtXKQ5HzEdM1UVnM-4A/viewform
 ---

--- a/_conferences/reactjsday-2022.md
+++ b/_conferences/reactjsday-2022.md
@@ -1,0 +1,9 @@
+---
+name: "Reactjsday"
+website: https://reactjsday.it/
+location: Verona
+online: true
+
+date_start: 2021-11-18
+date_end:   2021-11-18
+---

--- a/_conferences/rubyday-2022.md
+++ b/_conferences/rubyday-2022.md
@@ -1,0 +1,9 @@
+---
+name: "RubyDay"
+website: https://rubyday.it/
+location: Verona, Italy
+online: true
+
+date_start: 2022-10-21
+date_end:   2022-10-21
+---

--- a/_conferences/sfday-2022.md
+++ b/_conferences/sfday-2022.md
@@ -1,0 +1,9 @@
+---
+name: "sfday"
+website: http://www.grusp.org/
+location: Online
+online: true
+
+date_start: 2021-05-13
+date_end:   2021-05-13
+---

--- a/_conferences/vueday-2022.md
+++ b/_conferences/vueday-2022.md
@@ -1,0 +1,9 @@
+---
+name: "vueday"
+website: https://2022.vueday.it/
+location: Verona
+online: true
+
+date_start: 2022-09-30
+date_end:   2022-09-30
+---


### PR DESCRIPTION
Adding all the confs for 2022 from [Grusp](http://www.grusp.org/) that have a fixed date so far:

30edb2e70f1307716b433807fcae29de064ddccd Add ReactJs Day 2022
3684370de9df4d16f7fa44930f622e353784ca1f Add LaravelDay 2022
1c3e37b3551cd3bf5f37b55e54b01daa352b67c8 Add RubyDay 2022
fff49e11edc69c3ca1d7dac373fdcf3b2709d376 Add SF Day 2022
8e7151671c47d1d8b36221e031bbfd4631fabfdb Add VueDay 2022
0cd5ce772b099de89e7f2690ad3ffdb46ba3c6d9 Add CFP to PHP Day 2022
735564631bf7fe8327673fa4854004d073bf75ac Add CFP to JSS Day 2022