### PR TITLE
Fix broken generated links

### DIFF
--- a/conferences.ics
+++ b/conferences.ics
@@ -1,6 +1,6 @@
 ---
 layout: none
-uid_prefix: https://github.com/techconfit/techconfit.github.io/tree/main
+uid_prefix: https://github.com/techconfit/techconfit.github.io/tree/main/
 ---
 BEGIN:VCALENDAR
 VERSION:2.0


### PR DESCRIPTION
https://github.com/techconfit/techconfit.github.io/tree/main_conferences/accessibilitydays-2020.md

needs to be

https://github.com/techconfit/techconfit.github.io/tree/main/_conferences/accessibilitydays-2020.md